### PR TITLE
Fix window decorations on solid/square aurorae.

### DIFF
--- a/aurorae/cherry-solid/alldesktops.svg
+++ b/aurorae/cherry-solid/alldesktops.svg
@@ -1,0 +1,37 @@
+<svg id="svg4306" width="22" height="22" enable-background="new" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata id="metadata26">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g id="active-center">
+  <rect id="rect4266" width="22" height="22" opacity=".001"/>
+  <circle id="path4206" cx="11" cy="11" r="4" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="hover-center">
+  <g id="g4206" transform="translate(23)">
+   <rect id="rect4208" width="22" height="22" opacity=".001"/>
+  </g>
+  <circle id="circle4212" cx="34" cy="11" r="11" fill="#fafafa" opacity=".08"/>
+  <circle id="circle4213" cx="34" cy="11" r="4" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="pressed-center">
+  <g id="g4172" transform="translate(46)">
+   <rect id="rect4164" width="22" height="22" opacity=".001"/>
+  </g>
+  <circle id="path4202" cx="57" cy="11" r="11" fill="#fafafa" opacity=".19"/>
+  <circle id="circle4215" cx="57" cy="11" r="4" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="inactive-center" opacity=".5">
+  <rect id="rect4180" x="69" width="22" height="22" opacity=".001"/>
+  <circle id="circle4217" cx="80" cy="11" r="4" fill="#e4e6e8" fill-rule="evenodd" opacity=".3"/>
+ </g>
+ <g id="deactivated-center" opacity=".5">
+  <rect id="rect4278" x="92" width="22" height="22" opacity=".001"/>
+  <circle id="circle4219" cx="103" cy="11" r="4" fill="#e4e6e8" fill-rule="evenodd" opacity=".3"/>
+ </g>
+</svg>

--- a/aurorae/cherry-solid/close.svg
+++ b/aurorae/cherry-solid/close.svg
@@ -1,0 +1,42 @@
+<svg id="svg4306" width="22" height="22" enable-background="new" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata id="metadata31">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g id="active-center" transform="translate(-83.287 158.31)">
+  <g id="g6202-6" transform="translate(-1207.4 -402.64)">
+   <ellipse id="ellipse6176-7" cx="1302" cy="255" rx="8" ry="8" fill="#ff578b" opacity=".95"/>
+  </g>
+  <rect id="rect6204-9" x="86.625" y="-155.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="hover-center" transform="translate(-83.287 202.31)">
+  <g id="g6344-3" transform="translate(-1207.4 -402.64)">
+   <circle id="ellipse6320-6" cx="1302" cy="255" r="8" fill="#acb1bc"/>
+  </g>
+  <path id="path6346-2" d="m91.626-150.64h0.75c8e-3 -9e-5 0.0156-3.5e-4 0.0234 0 0.19122 8e-3 0.3824 0.0964 0.51563 0.23437l1.7109 1.7109 1.7344-1.7109c0.19922-0.17287 0.335-0.22912 0.51562-0.23437h0.75v0.75c0 0.21485-0.0257 0.41298-0.1875 0.5625l-1.7109 1.7109 1.6875 1.6875c0.14114 0.14113 0.21093 0.34009 0.21093 0.53907v0.75h-0.75c-0.19897-1e-5 -0.39793-0.0698-0.53906-0.21094l-1.7109-1.7109-1.7109 1.7109c-0.14113 0.14114-0.3401 0.21094-0.53907 0.21094h-0.75v-0.75c0-0.19897 0.0698-0.39794 0.21094-0.53907l1.7109-1.6875-1.7109-1.7109c-0.15805-0.14598-0.22737-0.35194-0.21094-0.5625v-0.75z" color="#c1c1c1" enable-background="new" fill="#fafafa" opacity=".75" style="text-decoration-line:none;text-indent:0;text-transform:none"/>
+  <rect id="rect6348-3" x="86.625" y="-155.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="pressed-center" transform="translate(-83.287 226.31)">
+  <g id="g6440-7" transform="translate(-1207.4 -402.64)">
+   <circle id="ellipse6416-5" cx="1302" cy="255" r="8" fill="#acb1bc"/>
+  </g>
+  <path id="path6442-9" d="m91.626-150.64h0.75c8e-3 -9e-5 0.0156-3.5e-4 0.0234 0 0.19122 8e-3 0.3824 0.0964 0.51563 0.23437l1.7109 1.7109 1.7344-1.7109c0.19922-0.17287 0.335-0.22912 0.51562-0.23437h0.75v0.75c0 0.21485-0.0257 0.41298-0.1875 0.5625l-1.7109 1.7109 1.6875 1.6875c0.14114 0.14113 0.21093 0.34009 0.21093 0.53907v0.75h-0.75c-0.19897-1e-5 -0.39793-0.0698-0.53906-0.21094l-1.7109-1.7109-1.7109 1.7109c-0.14113 0.14114-0.3401 0.21094-0.53907 0.21094h-0.75v-0.75c0-0.19897 0.0698-0.39794 0.21094-0.53907l1.7109-1.6875-1.7109-1.7109c-0.15805-0.14598-0.22737-0.35194-0.21094-0.5625v-0.75z" color="#c1c1c1" enable-background="new" fill="#fafafa" style="text-decoration-line:none;text-indent:0;text-transform:none"/>
+  <rect id="rect6444-3" x="86.625" y="-155.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="inactive-center" transform="translate(-83.287 179.31)">
+  <g id="g6532-9" transform="translate(-1207.4 -402.64)">
+   <ellipse id="ellipse6508-4" cx="1302" cy="255" rx="8" ry="8" fill="#ff578b"/>
+  </g>
+  <rect id="rect6534-3" x="86.625" y="-155.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="deactivated-center" transform="translate(-107.71 179.31)">
+  <g id="g1068" transform="translate(-1207.4 -402.64)">
+   <ellipse id="ellipse1046" cx="1302" cy="255" rx="8" ry="8" fill="#ff578b"/>
+  </g>
+  <rect id="rect1070" x="86.625" y="-155.64" width="16" height="16" fill="none"/>
+ </g>
+</svg>

--- a/aurorae/cherry-solid/keepabove.svg
+++ b/aurorae/cherry-solid/keepabove.svg
@@ -1,0 +1,24 @@
+<svg id="svg4306" width="22" height="22" enable-background="new" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <g id="active-center">
+  <rect id="rect4266" width="22" height="22" opacity=".001"/>
+  <path id="path4167" transform="matrix(.86603 0 0 .6 .47885 4.5829)" d="m12.149 4.0286 5.7735 10h-11.547l2.8868-5z" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="hover-center">
+  <rect id="rect4208" x="23" width="22" height="22" opacity=".001"/>
+  <circle id="circle4212" cx="34" cy="11" r="11" fill="#fafafa" opacity=".08"/>
+  <path id="path4171" d="m34 7 5 6h-10l2.5-3z" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="pressed-center">
+  <rect id="rect4164" x="46" width="22" height="22" opacity=".001"/>
+  <circle id="path4202" cx="57" cy="11" r="11" fill="#fafafa" opacity=".19"/>
+  <path id="path4173" d="m57 7 5 6h-10l2.5-3z" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="inactive-center">
+  <rect id="rect4179" x="69" width="22" height="22" opacity=".001"/>
+  <path id="path4181" transform="matrix(.86603 0 0 .6 69.479 4.5829)" d="m12.149 4.0286 5.7735 10h-11.547l2.8868-5z" fill="#e4e6e8" fill-rule="evenodd" opacity=".3"/>
+ </g>
+ <g id="deactivated-center">
+  <rect id="rect4183" x="92" width="22" height="22" opacity=".001"/>
+  <path id="path4185" transform="matrix(.86603 0 0 .6 92.479 4.5829)" d="m12.149 4.0286 5.7735 10h-11.547l2.8868-5z" fill="#e4e6e8" fill-rule="evenodd" opacity=".3"/>
+ </g>
+</svg>

--- a/aurorae/cherry-solid/keepbelow.svg
+++ b/aurorae/cherry-solid/keepbelow.svg
@@ -1,0 +1,24 @@
+<svg id="svg4306" width="22" height="22" enable-background="new" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <g id="active-center" transform="matrix(1,0,0,-1,0,22)">
+  <rect id="rect4266" width="22" height="22" opacity=".001"/>
+  <path id="path4167" transform="matrix(.86603 0 0 .6 .47885 4.5829)" d="m12.149 4.0286 5.7735 10h-11.547l2.8868-5z" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="hover-center" transform="matrix(1,0,0,-1,0,22)">
+  <rect id="rect4208" x="23" width="22" height="22" opacity=".001"/>
+  <circle id="circle4212" cx="34" cy="11" r="11" fill="#fafafa" opacity=".08"/>
+  <path id="path4171" d="m34 7 5 6h-10l2.5-3z" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="pressed-center" transform="matrix(1,0,0,-1,0,22)">
+  <rect id="rect4164" x="46" width="22" height="22" opacity=".001"/>
+  <circle id="path4202" cx="57" cy="11" r="11" fill="#fafafa" opacity=".19"/>
+  <path id="path4173" d="m57 7 5 6h-10l2.5-3z" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="inactive-center" transform="matrix(1,0,0,-1,0,22)">
+  <rect id="rect4179" x="69" width="22" height="22" opacity=".001"/>
+  <path id="path4181" transform="matrix(.86603 0 0 .6 69.479 4.5829)" d="m12.149 4.0286 5.7735 10h-11.547l2.8868-5z" fill="#e4e6e8" fill-rule="evenodd" opacity=".3"/>
+ </g>
+ <g id="deactivated-center" transform="matrix(1,0,0,-1,0,22)">
+  <rect id="rect4183" x="92" width="22" height="22" opacity=".001"/>
+  <path id="path4185" transform="matrix(.86603 0 0 .6 92.479 4.5829)" d="m12.149 4.0286 5.7735 10h-11.547l2.8868-5z" fill="#e4e6e8" fill-rule="evenodd" opacity=".3"/>
+ </g>
+</svg>

--- a/aurorae/cherry-solid/maximize.svg
+++ b/aurorae/cherry-solid/maximize.svg
@@ -1,0 +1,52 @@
+<svg id="svg4306" width="22" height="22" enable-background="new" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <metadata id="metadata24">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <use id="use1002" transform="translate(28.476)" width="100%" height="100%" xlink:href="#g1000"/>
+ <g id="active-center" transform="translate(-509.93 188.31)">
+  <g id="g4891-6-6" transform="translate(-781 -432.64)">
+   <ellipse id="path4068-7-5-9-6-7-2-4-9-7" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect17883-0-0-9" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="hover-center" transform="translate(-509.93 232.31)">
+  <g id="g6282-3" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6256-6" cx="1302" cy="255" rx="8" ry="8" fill="#acb1bc" fill-opacity=".96838" opacity=".5"/>
+   <g id="g6280-0" transform="translate(1294,247)" fill="#c0e3ff">
+    <g id="g6278-0" transform="translate(-81 -967)" fill="#c0e3ff">
+     <path id="path6276-2" d="m87.8 972h3.3817c0.4503 0 0.81623 0.36847 0.81876 0.8188v3.3817zm2.4074 6.0069h-3.3951c-0.45035 0-0.81876-0.36842-0.81876-0.81875v-3.3951l4.2138 4.2138" fill="#fafafa" fill-rule="evenodd" opacity=".75"/>
+    </g>
+   </g>
+  </g>
+  <rect id="rect6284-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="pressed-center" transform="translate(-509.93 256.31)">
+  <g id="g6378-7" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6352-5" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+   <g id="g6376-9" transform="translate(1294,247)" fill="#c0e3ff">
+    <g id="g6374-2" transform="translate(-81 -967)" fill="#c0e3ff">
+     <path id="path6372-9" d="m87.8 972h3.3817c0.4503 0 0.81623 0.36847 0.81876 0.8188v3.3817zm2.4074 6.0069h-3.3951c-0.45035 0-0.81876-0.36842-0.81876-0.81875v-3.3951l4.2138 4.2138" fill="#fafafa" fill-rule="evenodd"/>
+    </g>
+   </g>
+  </g>
+  <rect id="rect6380-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="inactive-center" transform="translate(-509.93 209.31)">
+  <g id="g6472-9" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6448-4" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect6474-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="deactivated-center" transform="translate(-534.18 209.31)">
+  <g id="g1055" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse1033" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect1057" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+</svg>

--- a/aurorae/cherry-solid/minimize.svg
+++ b/aurorae/cherry-solid/minimize.svg
@@ -1,0 +1,52 @@
+<svg id="svg4306" width="22" height="22" enable-background="new" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <metadata id="metadata24">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <use id="use1002" transform="translate(28.476)" width="100%" height="100%" xlink:href="#g1000"/>
+ <g id="active-center" transform="translate(-509.93 188.31)">
+  <g id="g4891-6-6" transform="translate(-781 -432.64)">
+   <ellipse id="path4068-7-5-9-6-7-2-4-9-7" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect17883-0-0-9" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="hover-center" transform="translate(-509.93 232.31)">
+  <g id="g6282-3" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6256-6" cx="1302" cy="255" rx="8" ry="8" fill="#acb1bc" fill-opacity=".96838" opacity=".5"/>
+   <g id="g6280-0" transform="translate(1294,247)" fill="#c0e3ff">
+    <g id="g6278-0" transform="translate(-81 -967)" fill="#c0e3ff">
+     <path id="path6276-2" d="m90.207 978.01h-3.3951c-0.45035 0-0.81876-0.36842-0.81876-0.81875v-3.3951l4.2138 4.2138" fill="#fafafa" fill-rule="evenodd" opacity=".75"/>
+    </g>
+   </g>
+  </g>
+  <rect id="rect6284-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="pressed-center" transform="translate(-509.93 256.31)">
+  <g id="g6378-7" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6352-5" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+   <g id="g6376-9" transform="translate(1294,247)" fill="#c0e3ff">
+    <g id="g6374-2" transform="translate(-81 -967)" fill="#c0e3ff">
+     <path id="path904" d="m90.207 978.01h-3.3951c-0.45035 0-0.81876-0.36842-0.81876-0.81875v-3.3951l4.2138 4.2138" fill="#fafafa" fill-rule="evenodd"/>
+    </g>
+   </g>
+  </g>
+  <rect id="rect6380-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="inactive-center" transform="translate(-509.93 209.31)">
+  <g id="g6472-9" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6448-4" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect6474-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="deactivated-center" transform="translate(-534.18 209.31)">
+  <g id="g1055" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse1033" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect1057" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+</svg>

--- a/aurorae/cherry-solid/restore.svg
+++ b/aurorae/cherry-solid/restore.svg
@@ -1,0 +1,52 @@
+<svg id="svg4306" width="22" height="22" enable-background="new" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <metadata id="metadata24">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <use id="use1002" transform="translate(28.476)" width="100%" height="100%" xlink:href="#g1000"/>
+ <g id="active-center" transform="translate(-509.93 188.31)">
+  <g id="g4891-6-6" transform="translate(-781 -432.64)">
+   <ellipse id="path4068-7-5-9-6-7-2-4-9-7" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect17883-0-0-9" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="hover-center" transform="translate(-509.93 232.31)">
+  <g id="g6282-3" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6256-6" cx="1302" cy="255" rx="8" ry="8" fill="#acb1bc" fill-opacity=".96838" opacity=".5"/>
+   <g id="g6280-0" transform="translate(1294,247)" fill="#c0e3ff">
+    <g id="g6278-0" transform="translate(-81 -967)" fill="#c0e3ff">
+     <path id="path6276-2" d="m87.8 972h3.3817c0.4503 0 0.81623 0.36847 0.81876 0.8188v3.3817zm2.4074 6.0069h-3.3951c-0.45035 0-0.81876-0.36842-0.81876-0.81875v-3.3951l4.2138 4.2138" fill="#fafafa" fill-rule="evenodd" opacity=".75"/>
+    </g>
+   </g>
+  </g>
+  <rect id="rect6284-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="pressed-center" transform="translate(-509.93 256.31)">
+  <g id="g6378-7" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6352-5" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+   <g id="g6376-9" transform="translate(1294,247)" fill="#c0e3ff">
+    <g id="g6374-2" transform="translate(-81 -967)" fill="#c0e3ff">
+     <path id="path6372-9" d="m87.8 972h3.3817c0.4503 0 0.81623 0.36847 0.81876 0.8188v3.3817zm2.4074 6.0069h-3.3951c-0.45035 0-0.81876-0.36842-0.81876-0.81875v-3.3951l4.2138 4.2138" fill="#fafafa" fill-rule="evenodd"/>
+    </g>
+   </g>
+  </g>
+  <rect id="rect6380-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="inactive-center" transform="translate(-509.93 209.31)">
+  <g id="g6472-9" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6448-4" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect6474-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="deactivated-center" transform="translate(-534.18 209.31)">
+  <g id="g1055" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse1033" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect1057" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+</svg>

--- a/aurorae/cherry-square-solid/alldesktops.svg
+++ b/aurorae/cherry-square-solid/alldesktops.svg
@@ -1,0 +1,37 @@
+<svg id="svg4306" width="22" height="22" enable-background="new" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata id="metadata26">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g id="active-center">
+  <rect id="rect4266" width="22" height="22" opacity=".001"/>
+  <circle id="path4206" cx="11" cy="11" r="4" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="hover-center">
+  <g id="g4206" transform="translate(23)">
+   <rect id="rect4208" width="22" height="22" opacity=".001"/>
+  </g>
+  <circle id="circle4212" cx="34" cy="11" r="11" fill="#fafafa" opacity=".08"/>
+  <circle id="circle4213" cx="34" cy="11" r="4" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="pressed-center">
+  <g id="g4172" transform="translate(46)">
+   <rect id="rect4164" width="22" height="22" opacity=".001"/>
+  </g>
+  <circle id="path4202" cx="57" cy="11" r="11" fill="#fafafa" opacity=".19"/>
+  <circle id="circle4215" cx="57" cy="11" r="4" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="inactive-center" opacity=".5">
+  <rect id="rect4180" x="69" width="22" height="22" opacity=".001"/>
+  <circle id="circle4217" cx="80" cy="11" r="4" fill="#e4e6e8" fill-rule="evenodd" opacity=".3"/>
+ </g>
+ <g id="deactivated-center" opacity=".5">
+  <rect id="rect4278" x="92" width="22" height="22" opacity=".001"/>
+  <circle id="circle4219" cx="103" cy="11" r="4" fill="#e4e6e8" fill-rule="evenodd" opacity=".3"/>
+ </g>
+</svg>

--- a/aurorae/cherry-square-solid/close.svg
+++ b/aurorae/cherry-square-solid/close.svg
@@ -1,0 +1,42 @@
+<svg id="svg4306" width="22" height="22" enable-background="new" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata id="metadata31">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g id="active-center" transform="translate(-83.287 158.31)">
+  <g id="g6202-6" transform="translate(-1207.4 -402.64)">
+   <ellipse id="ellipse6176-7" cx="1302" cy="255" rx="8" ry="8" fill="#ff578b" opacity=".95"/>
+  </g>
+  <rect id="rect6204-9" x="86.625" y="-155.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="hover-center" transform="translate(-83.287 202.31)">
+  <g id="g6344-3" transform="translate(-1207.4 -402.64)">
+   <circle id="ellipse6320-6" cx="1302" cy="255" r="8" fill="#acb1bc"/>
+  </g>
+  <path id="path6346-2" d="m91.626-150.64h0.75c8e-3 -9e-5 0.0156-3.5e-4 0.0234 0 0.19122 8e-3 0.3824 0.0964 0.51563 0.23437l1.7109 1.7109 1.7344-1.7109c0.19922-0.17287 0.335-0.22912 0.51562-0.23437h0.75v0.75c0 0.21485-0.0257 0.41298-0.1875 0.5625l-1.7109 1.7109 1.6875 1.6875c0.14114 0.14113 0.21093 0.34009 0.21093 0.53907v0.75h-0.75c-0.19897-1e-5 -0.39793-0.0698-0.53906-0.21094l-1.7109-1.7109-1.7109 1.7109c-0.14113 0.14114-0.3401 0.21094-0.53907 0.21094h-0.75v-0.75c0-0.19897 0.0698-0.39794 0.21094-0.53907l1.7109-1.6875-1.7109-1.7109c-0.15805-0.14598-0.22737-0.35194-0.21094-0.5625v-0.75z" color="#c1c1c1" enable-background="new" fill="#fafafa" opacity=".75" style="text-decoration-line:none;text-indent:0;text-transform:none"/>
+  <rect id="rect6348-3" x="86.625" y="-155.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="pressed-center" transform="translate(-83.287 226.31)">
+  <g id="g6440-7" transform="translate(-1207.4 -402.64)">
+   <circle id="ellipse6416-5" cx="1302" cy="255" r="8" fill="#acb1bc"/>
+  </g>
+  <path id="path6442-9" d="m91.626-150.64h0.75c8e-3 -9e-5 0.0156-3.5e-4 0.0234 0 0.19122 8e-3 0.3824 0.0964 0.51563 0.23437l1.7109 1.7109 1.7344-1.7109c0.19922-0.17287 0.335-0.22912 0.51562-0.23437h0.75v0.75c0 0.21485-0.0257 0.41298-0.1875 0.5625l-1.7109 1.7109 1.6875 1.6875c0.14114 0.14113 0.21093 0.34009 0.21093 0.53907v0.75h-0.75c-0.19897-1e-5 -0.39793-0.0698-0.53906-0.21094l-1.7109-1.7109-1.7109 1.7109c-0.14113 0.14114-0.3401 0.21094-0.53907 0.21094h-0.75v-0.75c0-0.19897 0.0698-0.39794 0.21094-0.53907l1.7109-1.6875-1.7109-1.7109c-0.15805-0.14598-0.22737-0.35194-0.21094-0.5625v-0.75z" color="#c1c1c1" enable-background="new" fill="#fafafa" style="text-decoration-line:none;text-indent:0;text-transform:none"/>
+  <rect id="rect6444-3" x="86.625" y="-155.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="inactive-center" transform="translate(-83.287 179.31)">
+  <g id="g6532-9" transform="translate(-1207.4 -402.64)">
+   <ellipse id="ellipse6508-4" cx="1302" cy="255" rx="8" ry="8" fill="#ff578b"/>
+  </g>
+  <rect id="rect6534-3" x="86.625" y="-155.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="deactivated-center" transform="translate(-107.71 179.31)">
+  <g id="g1068" transform="translate(-1207.4 -402.64)">
+   <ellipse id="ellipse1046" cx="1302" cy="255" rx="8" ry="8" fill="#ff578b"/>
+  </g>
+  <rect id="rect1070" x="86.625" y="-155.64" width="16" height="16" fill="none"/>
+ </g>
+</svg>

--- a/aurorae/cherry-square-solid/keepabove.svg
+++ b/aurorae/cherry-square-solid/keepabove.svg
@@ -1,0 +1,24 @@
+<svg id="svg4306" width="22" height="22" enable-background="new" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <g id="active-center">
+  <rect id="rect4266" width="22" height="22" opacity=".001"/>
+  <path id="path4167" transform="matrix(.86603 0 0 .6 .47885 4.5829)" d="m12.149 4.0286 5.7735 10h-11.547l2.8868-5z" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="hover-center">
+  <rect id="rect4208" x="23" width="22" height="22" opacity=".001"/>
+  <circle id="circle4212" cx="34" cy="11" r="11" fill="#fafafa" opacity=".08"/>
+  <path id="path4171" d="m34 7 5 6h-10l2.5-3z" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="pressed-center">
+  <rect id="rect4164" x="46" width="22" height="22" opacity=".001"/>
+  <circle id="path4202" cx="57" cy="11" r="11" fill="#fafafa" opacity=".19"/>
+  <path id="path4173" d="m57 7 5 6h-10l2.5-3z" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="inactive-center">
+  <rect id="rect4179" x="69" width="22" height="22" opacity=".001"/>
+  <path id="path4181" transform="matrix(.86603 0 0 .6 69.479 4.5829)" d="m12.149 4.0286 5.7735 10h-11.547l2.8868-5z" fill="#e4e6e8" fill-rule="evenodd" opacity=".3"/>
+ </g>
+ <g id="deactivated-center">
+  <rect id="rect4183" x="92" width="22" height="22" opacity=".001"/>
+  <path id="path4185" transform="matrix(.86603 0 0 .6 92.479 4.5829)" d="m12.149 4.0286 5.7735 10h-11.547l2.8868-5z" fill="#e4e6e8" fill-rule="evenodd" opacity=".3"/>
+ </g>
+</svg>

--- a/aurorae/cherry-square-solid/keepbelow.svg
+++ b/aurorae/cherry-square-solid/keepbelow.svg
@@ -1,0 +1,24 @@
+<svg id="svg4306" width="22" height="22" enable-background="new" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <g id="active-center" transform="matrix(1,0,0,-1,0,22)">
+  <rect id="rect4266" width="22" height="22" opacity=".001"/>
+  <path id="path4167" transform="matrix(.86603 0 0 .6 .47885 4.5829)" d="m12.149 4.0286 5.7735 10h-11.547l2.8868-5z" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="hover-center" transform="matrix(1,0,0,-1,0,22)">
+  <rect id="rect4208" x="23" width="22" height="22" opacity=".001"/>
+  <circle id="circle4212" cx="34" cy="11" r="11" fill="#fafafa" opacity=".08"/>
+  <path id="path4171" d="m34 7 5 6h-10l2.5-3z" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="pressed-center" transform="matrix(1,0,0,-1,0,22)">
+  <rect id="rect4164" x="46" width="22" height="22" opacity=".001"/>
+  <circle id="path4202" cx="57" cy="11" r="11" fill="#fafafa" opacity=".19"/>
+  <path id="path4173" d="m57 7 5 6h-10l2.5-3z" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="inactive-center" transform="matrix(1,0,0,-1,0,22)">
+  <rect id="rect4179" x="69" width="22" height="22" opacity=".001"/>
+  <path id="path4181" transform="matrix(.86603 0 0 .6 69.479 4.5829)" d="m12.149 4.0286 5.7735 10h-11.547l2.8868-5z" fill="#e4e6e8" fill-rule="evenodd" opacity=".3"/>
+ </g>
+ <g id="deactivated-center" transform="matrix(1,0,0,-1,0,22)">
+  <rect id="rect4183" x="92" width="22" height="22" opacity=".001"/>
+  <path id="path4185" transform="matrix(.86603 0 0 .6 92.479 4.5829)" d="m12.149 4.0286 5.7735 10h-11.547l2.8868-5z" fill="#e4e6e8" fill-rule="evenodd" opacity=".3"/>
+ </g>
+</svg>

--- a/aurorae/cherry-square-solid/maximize.svg
+++ b/aurorae/cherry-square-solid/maximize.svg
@@ -1,0 +1,52 @@
+<svg id="svg4306" width="22" height="22" enable-background="new" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <metadata id="metadata24">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <use id="use1002" transform="translate(28.476)" width="100%" height="100%" xlink:href="#g1000"/>
+ <g id="active-center" transform="translate(-509.93 188.31)">
+  <g id="g4891-6-6" transform="translate(-781 -432.64)">
+   <ellipse id="path4068-7-5-9-6-7-2-4-9-7" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect17883-0-0-9" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="hover-center" transform="translate(-509.93 232.31)">
+  <g id="g6282-3" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6256-6" cx="1302" cy="255" rx="8" ry="8" fill="#acb1bc" fill-opacity=".96838" opacity=".5"/>
+   <g id="g6280-0" transform="translate(1294,247)" fill="#c0e3ff">
+    <g id="g6278-0" transform="translate(-81 -967)" fill="#c0e3ff">
+     <path id="path6276-2" d="m87.8 972h3.3817c0.4503 0 0.81623 0.36847 0.81876 0.8188v3.3817zm2.4074 6.0069h-3.3951c-0.45035 0-0.81876-0.36842-0.81876-0.81875v-3.3951l4.2138 4.2138" fill="#fafafa" fill-rule="evenodd" opacity=".75"/>
+    </g>
+   </g>
+  </g>
+  <rect id="rect6284-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="pressed-center" transform="translate(-509.93 256.31)">
+  <g id="g6378-7" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6352-5" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+   <g id="g6376-9" transform="translate(1294,247)" fill="#c0e3ff">
+    <g id="g6374-2" transform="translate(-81 -967)" fill="#c0e3ff">
+     <path id="path6372-9" d="m87.8 972h3.3817c0.4503 0 0.81623 0.36847 0.81876 0.8188v3.3817zm2.4074 6.0069h-3.3951c-0.45035 0-0.81876-0.36842-0.81876-0.81875v-3.3951l4.2138 4.2138" fill="#fafafa" fill-rule="evenodd"/>
+    </g>
+   </g>
+  </g>
+  <rect id="rect6380-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="inactive-center" transform="translate(-509.93 209.31)">
+  <g id="g6472-9" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6448-4" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect6474-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="deactivated-center" transform="translate(-534.18 209.31)">
+  <g id="g1055" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse1033" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect1057" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+</svg>

--- a/aurorae/cherry-square-solid/minimize.svg
+++ b/aurorae/cherry-square-solid/minimize.svg
@@ -1,0 +1,52 @@
+<svg id="svg4306" width="22" height="22" enable-background="new" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <metadata id="metadata24">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <use id="use1002" transform="translate(28.476)" width="100%" height="100%" xlink:href="#g1000"/>
+ <g id="active-center" transform="translate(-509.93 188.31)">
+  <g id="g4891-6-6" transform="translate(-781 -432.64)">
+   <ellipse id="path4068-7-5-9-6-7-2-4-9-7" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect17883-0-0-9" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="hover-center" transform="translate(-509.93 232.31)">
+  <g id="g6282-3" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6256-6" cx="1302" cy="255" rx="8" ry="8" fill="#acb1bc" fill-opacity=".96838" opacity=".5"/>
+   <g id="g6280-0" transform="translate(1294,247)" fill="#c0e3ff">
+    <g id="g6278-0" transform="translate(-81 -967)" fill="#c0e3ff">
+     <path id="path6276-2" d="m90.207 978.01h-3.3951c-0.45035 0-0.81876-0.36842-0.81876-0.81875v-3.3951l4.2138 4.2138" fill="#fafafa" fill-rule="evenodd" opacity=".75"/>
+    </g>
+   </g>
+  </g>
+  <rect id="rect6284-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="pressed-center" transform="translate(-509.93 256.31)">
+  <g id="g6378-7" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6352-5" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+   <g id="g6376-9" transform="translate(1294,247)" fill="#c0e3ff">
+    <g id="g6374-2" transform="translate(-81 -967)" fill="#c0e3ff">
+     <path id="path904" d="m90.207 978.01h-3.3951c-0.45035 0-0.81876-0.36842-0.81876-0.81875v-3.3951l4.2138 4.2138" fill="#fafafa" fill-rule="evenodd"/>
+    </g>
+   </g>
+  </g>
+  <rect id="rect6380-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="inactive-center" transform="translate(-509.93 209.31)">
+  <g id="g6472-9" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6448-4" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect6474-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="deactivated-center" transform="translate(-534.18 209.31)">
+  <g id="g1055" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse1033" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect1057" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+</svg>

--- a/aurorae/cherry-square-solid/restore.svg
+++ b/aurorae/cherry-square-solid/restore.svg
@@ -1,0 +1,52 @@
+<svg id="svg4306" width="22" height="22" enable-background="new" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <metadata id="metadata24">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <use id="use1002" transform="translate(28.476)" width="100%" height="100%" xlink:href="#g1000"/>
+ <g id="active-center" transform="translate(-509.93 188.31)">
+  <g id="g4891-6-6" transform="translate(-781 -432.64)">
+   <ellipse id="path4068-7-5-9-6-7-2-4-9-7" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect17883-0-0-9" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="hover-center" transform="translate(-509.93 232.31)">
+  <g id="g6282-3" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6256-6" cx="1302" cy="255" rx="8" ry="8" fill="#acb1bc" fill-opacity=".96838" opacity=".5"/>
+   <g id="g6280-0" transform="translate(1294,247)" fill="#c0e3ff">
+    <g id="g6278-0" transform="translate(-81 -967)" fill="#c0e3ff">
+     <path id="path6276-2" d="m87.8 972h3.3817c0.4503 0 0.81623 0.36847 0.81876 0.8188v3.3817zm2.4074 6.0069h-3.3951c-0.45035 0-0.81876-0.36842-0.81876-0.81875v-3.3951l4.2138 4.2138" fill="#fafafa" fill-rule="evenodd" opacity=".75"/>
+    </g>
+   </g>
+  </g>
+  <rect id="rect6284-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="pressed-center" transform="translate(-509.93 256.31)">
+  <g id="g6378-7" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6352-5" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+   <g id="g6376-9" transform="translate(1294,247)" fill="#c0e3ff">
+    <g id="g6374-2" transform="translate(-81 -967)" fill="#c0e3ff">
+     <path id="path6372-9" d="m87.8 972h3.3817c0.4503 0 0.81623 0.36847 0.81876 0.8188v3.3817zm2.4074 6.0069h-3.3951c-0.45035 0-0.81876-0.36842-0.81876-0.81875v-3.3951l4.2138 4.2138" fill="#fafafa" fill-rule="evenodd"/>
+    </g>
+   </g>
+  </g>
+  <rect id="rect6380-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="inactive-center" transform="translate(-509.93 209.31)">
+  <g id="g6472-9" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6448-4" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect6474-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="deactivated-center" transform="translate(-534.18 209.31)">
+  <g id="g1055" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse1033" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect1057" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+</svg>

--- a/aurorae/cherry-square/alldesktops.svg
+++ b/aurorae/cherry-square/alldesktops.svg
@@ -1,0 +1,37 @@
+<svg id="svg4306" width="22" height="22" enable-background="new" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata id="metadata26">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g id="active-center">
+  <rect id="rect4266" width="22" height="22" opacity=".001"/>
+  <circle id="path4206" cx="11" cy="11" r="4" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="hover-center">
+  <g id="g4206" transform="translate(23)">
+   <rect id="rect4208" width="22" height="22" opacity=".001"/>
+  </g>
+  <circle id="circle4212" cx="34" cy="11" r="11" fill="#fafafa" opacity=".08"/>
+  <circle id="circle4213" cx="34" cy="11" r="4" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="pressed-center">
+  <g id="g4172" transform="translate(46)">
+   <rect id="rect4164" width="22" height="22" opacity=".001"/>
+  </g>
+  <circle id="path4202" cx="57" cy="11" r="11" fill="#fafafa" opacity=".19"/>
+  <circle id="circle4215" cx="57" cy="11" r="4" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="inactive-center" opacity=".5">
+  <rect id="rect4180" x="69" width="22" height="22" opacity=".001"/>
+  <circle id="circle4217" cx="80" cy="11" r="4" fill="#e4e6e8" fill-rule="evenodd" opacity=".3"/>
+ </g>
+ <g id="deactivated-center" opacity=".5">
+  <rect id="rect4278" x="92" width="22" height="22" opacity=".001"/>
+  <circle id="circle4219" cx="103" cy="11" r="4" fill="#e4e6e8" fill-rule="evenodd" opacity=".3"/>
+ </g>
+</svg>

--- a/aurorae/cherry-square/close.svg
+++ b/aurorae/cherry-square/close.svg
@@ -1,0 +1,42 @@
+<svg id="svg4306" width="22" height="22" enable-background="new" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata id="metadata31">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g id="active-center" transform="translate(-83.287 158.31)">
+  <g id="g6202-6" transform="translate(-1207.4 -402.64)">
+   <ellipse id="ellipse6176-7" cx="1302" cy="255" rx="8" ry="8" fill="#ff578b" opacity=".95"/>
+  </g>
+  <rect id="rect6204-9" x="86.625" y="-155.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="hover-center" transform="translate(-83.287 202.31)">
+  <g id="g6344-3" transform="translate(-1207.4 -402.64)">
+   <circle id="ellipse6320-6" cx="1302" cy="255" r="8" fill="#acb1bc"/>
+  </g>
+  <path id="path6346-2" d="m91.626-150.64h0.75c8e-3 -9e-5 0.0156-3.5e-4 0.0234 0 0.19122 8e-3 0.3824 0.0964 0.51563 0.23437l1.7109 1.7109 1.7344-1.7109c0.19922-0.17287 0.335-0.22912 0.51562-0.23437h0.75v0.75c0 0.21485-0.0257 0.41298-0.1875 0.5625l-1.7109 1.7109 1.6875 1.6875c0.14114 0.14113 0.21093 0.34009 0.21093 0.53907v0.75h-0.75c-0.19897-1e-5 -0.39793-0.0698-0.53906-0.21094l-1.7109-1.7109-1.7109 1.7109c-0.14113 0.14114-0.3401 0.21094-0.53907 0.21094h-0.75v-0.75c0-0.19897 0.0698-0.39794 0.21094-0.53907l1.7109-1.6875-1.7109-1.7109c-0.15805-0.14598-0.22737-0.35194-0.21094-0.5625v-0.75z" color="#c1c1c1" enable-background="new" fill="#fafafa" opacity=".75" style="text-decoration-line:none;text-indent:0;text-transform:none"/>
+  <rect id="rect6348-3" x="86.625" y="-155.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="pressed-center" transform="translate(-83.287 226.31)">
+  <g id="g6440-7" transform="translate(-1207.4 -402.64)">
+   <circle id="ellipse6416-5" cx="1302" cy="255" r="8" fill="#acb1bc"/>
+  </g>
+  <path id="path6442-9" d="m91.626-150.64h0.75c8e-3 -9e-5 0.0156-3.5e-4 0.0234 0 0.19122 8e-3 0.3824 0.0964 0.51563 0.23437l1.7109 1.7109 1.7344-1.7109c0.19922-0.17287 0.335-0.22912 0.51562-0.23437h0.75v0.75c0 0.21485-0.0257 0.41298-0.1875 0.5625l-1.7109 1.7109 1.6875 1.6875c0.14114 0.14113 0.21093 0.34009 0.21093 0.53907v0.75h-0.75c-0.19897-1e-5 -0.39793-0.0698-0.53906-0.21094l-1.7109-1.7109-1.7109 1.7109c-0.14113 0.14114-0.3401 0.21094-0.53907 0.21094h-0.75v-0.75c0-0.19897 0.0698-0.39794 0.21094-0.53907l1.7109-1.6875-1.7109-1.7109c-0.15805-0.14598-0.22737-0.35194-0.21094-0.5625v-0.75z" color="#c1c1c1" enable-background="new" fill="#fafafa" style="text-decoration-line:none;text-indent:0;text-transform:none"/>
+  <rect id="rect6444-3" x="86.625" y="-155.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="inactive-center" transform="translate(-83.287 179.31)">
+  <g id="g6532-9" transform="translate(-1207.4 -402.64)">
+   <ellipse id="ellipse6508-4" cx="1302" cy="255" rx="8" ry="8" fill="#ff578b"/>
+  </g>
+  <rect id="rect6534-3" x="86.625" y="-155.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="deactivated-center" transform="translate(-107.71 179.31)">
+  <g id="g1068" transform="translate(-1207.4 -402.64)">
+   <ellipse id="ellipse1046" cx="1302" cy="255" rx="8" ry="8" fill="#ff578b"/>
+  </g>
+  <rect id="rect1070" x="86.625" y="-155.64" width="16" height="16" fill="none"/>
+ </g>
+</svg>

--- a/aurorae/cherry-square/keepabove.svg
+++ b/aurorae/cherry-square/keepabove.svg
@@ -1,0 +1,24 @@
+<svg id="svg4306" width="22" height="22" enable-background="new" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <g id="active-center">
+  <rect id="rect4266" width="22" height="22" opacity=".001"/>
+  <path id="path4167" transform="matrix(.86603 0 0 .6 .47885 4.5829)" d="m12.149 4.0286 5.7735 10h-11.547l2.8868-5z" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="hover-center">
+  <rect id="rect4208" x="23" width="22" height="22" opacity=".001"/>
+  <circle id="circle4212" cx="34" cy="11" r="11" fill="#fafafa" opacity=".08"/>
+  <path id="path4171" d="m34 7 5 6h-10l2.5-3z" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="pressed-center">
+  <rect id="rect4164" x="46" width="22" height="22" opacity=".001"/>
+  <circle id="path4202" cx="57" cy="11" r="11" fill="#fafafa" opacity=".19"/>
+  <path id="path4173" d="m57 7 5 6h-10l2.5-3z" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="inactive-center">
+  <rect id="rect4179" x="69" width="22" height="22" opacity=".001"/>
+  <path id="path4181" transform="matrix(.86603 0 0 .6 69.479 4.5829)" d="m12.149 4.0286 5.7735 10h-11.547l2.8868-5z" fill="#e4e6e8" fill-rule="evenodd" opacity=".3"/>
+ </g>
+ <g id="deactivated-center">
+  <rect id="rect4183" x="92" width="22" height="22" opacity=".001"/>
+  <path id="path4185" transform="matrix(.86603 0 0 .6 92.479 4.5829)" d="m12.149 4.0286 5.7735 10h-11.547l2.8868-5z" fill="#e4e6e8" fill-rule="evenodd" opacity=".3"/>
+ </g>
+</svg>

--- a/aurorae/cherry-square/keepbelow.svg
+++ b/aurorae/cherry-square/keepbelow.svg
@@ -1,0 +1,24 @@
+<svg id="svg4306" width="22" height="22" enable-background="new" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <g id="active-center" transform="matrix(1,0,0,-1,0,22)">
+  <rect id="rect4266" width="22" height="22" opacity=".001"/>
+  <path id="path4167" transform="matrix(.86603 0 0 .6 .47885 4.5829)" d="m12.149 4.0286 5.7735 10h-11.547l2.8868-5z" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="hover-center" transform="matrix(1,0,0,-1,0,22)">
+  <rect id="rect4208" x="23" width="22" height="22" opacity=".001"/>
+  <circle id="circle4212" cx="34" cy="11" r="11" fill="#fafafa" opacity=".08"/>
+  <path id="path4171" d="m34 7 5 6h-10l2.5-3z" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="pressed-center" transform="matrix(1,0,0,-1,0,22)">
+  <rect id="rect4164" x="46" width="22" height="22" opacity=".001"/>
+  <circle id="path4202" cx="57" cy="11" r="11" fill="#fafafa" opacity=".19"/>
+  <path id="path4173" d="m57 7 5 6h-10l2.5-3z" fill="#e4e6e8" fill-rule="evenodd"/>
+ </g>
+ <g id="inactive-center" transform="matrix(1,0,0,-1,0,22)">
+  <rect id="rect4179" x="69" width="22" height="22" opacity=".001"/>
+  <path id="path4181" transform="matrix(.86603 0 0 .6 69.479 4.5829)" d="m12.149 4.0286 5.7735 10h-11.547l2.8868-5z" fill="#e4e6e8" fill-rule="evenodd" opacity=".3"/>
+ </g>
+ <g id="deactivated-center" transform="matrix(1,0,0,-1,0,22)">
+  <rect id="rect4183" x="92" width="22" height="22" opacity=".001"/>
+  <path id="path4185" transform="matrix(.86603 0 0 .6 92.479 4.5829)" d="m12.149 4.0286 5.7735 10h-11.547l2.8868-5z" fill="#e4e6e8" fill-rule="evenodd" opacity=".3"/>
+ </g>
+</svg>

--- a/aurorae/cherry-square/maximize.svg
+++ b/aurorae/cherry-square/maximize.svg
@@ -1,0 +1,52 @@
+<svg id="svg4306" width="22" height="22" enable-background="new" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <metadata id="metadata24">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <use id="use1002" transform="translate(28.476)" width="100%" height="100%" xlink:href="#g1000"/>
+ <g id="active-center" transform="translate(-509.93 188.31)">
+  <g id="g4891-6-6" transform="translate(-781 -432.64)">
+   <ellipse id="path4068-7-5-9-6-7-2-4-9-7" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect17883-0-0-9" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="hover-center" transform="translate(-509.93 232.31)">
+  <g id="g6282-3" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6256-6" cx="1302" cy="255" rx="8" ry="8" fill="#acb1bc" fill-opacity=".96838" opacity=".5"/>
+   <g id="g6280-0" transform="translate(1294,247)" fill="#c0e3ff">
+    <g id="g6278-0" transform="translate(-81 -967)" fill="#c0e3ff">
+     <path id="path6276-2" d="m87.8 972h3.3817c0.4503 0 0.81623 0.36847 0.81876 0.8188v3.3817zm2.4074 6.0069h-3.3951c-0.45035 0-0.81876-0.36842-0.81876-0.81875v-3.3951l4.2138 4.2138" fill="#fafafa" fill-rule="evenodd" opacity=".75"/>
+    </g>
+   </g>
+  </g>
+  <rect id="rect6284-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="pressed-center" transform="translate(-509.93 256.31)">
+  <g id="g6378-7" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6352-5" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+   <g id="g6376-9" transform="translate(1294,247)" fill="#c0e3ff">
+    <g id="g6374-2" transform="translate(-81 -967)" fill="#c0e3ff">
+     <path id="path6372-9" d="m87.8 972h3.3817c0.4503 0 0.81623 0.36847 0.81876 0.8188v3.3817zm2.4074 6.0069h-3.3951c-0.45035 0-0.81876-0.36842-0.81876-0.81875v-3.3951l4.2138 4.2138" fill="#fafafa" fill-rule="evenodd"/>
+    </g>
+   </g>
+  </g>
+  <rect id="rect6380-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="inactive-center" transform="translate(-509.93 209.31)">
+  <g id="g6472-9" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6448-4" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect6474-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="deactivated-center" transform="translate(-534.18 209.31)">
+  <g id="g1055" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse1033" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect1057" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+</svg>

--- a/aurorae/cherry-square/minimize.svg
+++ b/aurorae/cherry-square/minimize.svg
@@ -1,0 +1,52 @@
+<svg id="svg4306" width="22" height="22" enable-background="new" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <metadata id="metadata24">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <use id="use1002" transform="translate(28.476)" width="100%" height="100%" xlink:href="#g1000"/>
+ <g id="active-center" transform="translate(-509.93 188.31)">
+  <g id="g4891-6-6" transform="translate(-781 -432.64)">
+   <ellipse id="path4068-7-5-9-6-7-2-4-9-7" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect17883-0-0-9" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="hover-center" transform="translate(-509.93 232.31)">
+  <g id="g6282-3" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6256-6" cx="1302" cy="255" rx="8" ry="8" fill="#acb1bc" fill-opacity=".96838" opacity=".5"/>
+   <g id="g6280-0" transform="translate(1294,247)" fill="#c0e3ff">
+    <g id="g6278-0" transform="translate(-81 -967)" fill="#c0e3ff">
+     <path id="path6276-2" d="m90.207 978.01h-3.3951c-0.45035 0-0.81876-0.36842-0.81876-0.81875v-3.3951l4.2138 4.2138" fill="#fafafa" fill-rule="evenodd" opacity=".75"/>
+    </g>
+   </g>
+  </g>
+  <rect id="rect6284-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="pressed-center" transform="translate(-509.93 256.31)">
+  <g id="g6378-7" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6352-5" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+   <g id="g6376-9" transform="translate(1294,247)" fill="#c0e3ff">
+    <g id="g6374-2" transform="translate(-81 -967)" fill="#c0e3ff">
+     <path id="path904" d="m90.207 978.01h-3.3951c-0.45035 0-0.81876-0.36842-0.81876-0.81875v-3.3951l4.2138 4.2138" fill="#fafafa" fill-rule="evenodd"/>
+    </g>
+   </g>
+  </g>
+  <rect id="rect6380-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="inactive-center" transform="translate(-509.93 209.31)">
+  <g id="g6472-9" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6448-4" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect6474-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="deactivated-center" transform="translate(-534.18 209.31)">
+  <g id="g1055" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse1033" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect1057" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+</svg>

--- a/aurorae/cherry-square/restore.svg
+++ b/aurorae/cherry-square/restore.svg
@@ -1,0 +1,52 @@
+<svg id="svg4306" width="22" height="22" enable-background="new" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <metadata id="metadata24">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <use id="use1002" transform="translate(28.476)" width="100%" height="100%" xlink:href="#g1000"/>
+ <g id="active-center" transform="translate(-509.93 188.31)">
+  <g id="g4891-6-6" transform="translate(-781 -432.64)">
+   <ellipse id="path4068-7-5-9-6-7-2-4-9-7" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect17883-0-0-9" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="hover-center" transform="translate(-509.93 232.31)">
+  <g id="g6282-3" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6256-6" cx="1302" cy="255" rx="8" ry="8" fill="#acb1bc" fill-opacity=".96838" opacity=".5"/>
+   <g id="g6280-0" transform="translate(1294,247)" fill="#c0e3ff">
+    <g id="g6278-0" transform="translate(-81 -967)" fill="#c0e3ff">
+     <path id="path6276-2" d="m87.8 972h3.3817c0.4503 0 0.81623 0.36847 0.81876 0.8188v3.3817zm2.4074 6.0069h-3.3951c-0.45035 0-0.81876-0.36842-0.81876-0.81875v-3.3951l4.2138 4.2138" fill="#fafafa" fill-rule="evenodd" opacity=".75"/>
+    </g>
+   </g>
+  </g>
+  <rect id="rect6284-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="pressed-center" transform="translate(-509.93 256.31)">
+  <g id="g6378-7" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6352-5" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+   <g id="g6376-9" transform="translate(1294,247)" fill="#c0e3ff">
+    <g id="g6374-2" transform="translate(-81 -967)" fill="#c0e3ff">
+     <path id="path6372-9" d="m87.8 972h3.3817c0.4503 0 0.81623 0.36847 0.81876 0.8188v3.3817zm2.4074 6.0069h-3.3951c-0.45035 0-0.81876-0.36842-0.81876-0.81875v-3.3951l4.2138 4.2138" fill="#fafafa" fill-rule="evenodd"/>
+    </g>
+   </g>
+  </g>
+  <rect id="rect6380-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="inactive-center" transform="translate(-509.93 209.31)">
+  <g id="g6472-9" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse6448-4" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect6474-3" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+ <g id="deactivated-center" transform="translate(-534.18 209.31)">
+  <g id="g1055" transform="translate(-781 -432.64)">
+   <ellipse id="ellipse1033" cx="1302" cy="255" rx="8" ry="8" fill="#7f9bff"/>
+  </g>
+  <rect id="rect1057" x="513" y="-185.64" width="16" height="16" fill="none"/>
+ </g>
+</svg>


### PR DESCRIPTION
The window decoration buttons were not working in the alternative themes for newer versions of Plasma. Just adding the svg files to each theme fixes the issue.